### PR TITLE
Remove Persona sites from httpobs dashboard

### DIFF
--- a/httpobsdashboard/conf/sites.json
+++ b/httpobsdashboard/conf/sites.json
@@ -66,21 +66,6 @@
       "observatory.mozilla.org",
       "tls-observatory.services.mozilla.com"
     ],
-    "Persona": [
-      "browserid.org",
-      "www.browserid.org",
-      "firefoxos.persona.org",
-      "persona.org",
-      "www.persona.org",
-      "static.login.persona.org",
-      "verifier.login.persona.org",
-      "yahoo.login.persona.org",
-      "gmail.login.persona.org",
-      "login.anosrep.org",
-      "login.mozilla.org",
-      "login.persona.org",
-      "diresworb.org"
-    ],
     "Push": [
       "push.services.mozilla.com",
       "updates.push.services.mozilla.com"


### PR DESCRIPTION
Persona was removed from Web Bug Bounty program on 11/30/2016