### PR TITLE
Open dashboard links in new tab

### DIFF
--- a/httpobsdashboard/templates/index.html
+++ b/httpobsdashboard/templates/index.html
@@ -43,7 +43,7 @@
                 {% for hostname, results in site.items() %}
                 <tr>
                     <td>
-                        <a href="{% if results.tlsobs.data.has_tls %}https{% else %}http{% endif %}://{{hostname}}/">{{ hostname }}</a>
+                        <a href="{% if results.tlsobs.data.has_tls %}https{% else %}http{% endif %}://{{hostname}}/" target="_blank" rel="noopener noreferrer">{{ hostname }}</a>
                         {% if results.httpobs.tests.contribute.pass and results.httpobs.tests.contribute.output.data %}
                             <span class="glyphicon glyphicon-info-sign pull-right" data-container="body" data-toggle="popover" title="" data-content="
                             <div>{{ results.httpobs.tests.contribute.output.data.description }}</div>


### PR DESCRIPTION
Current logic loads the links in the current tab/frame, and may or may not load them correctly, depending on their CSP configuration.

This opens the links into a new browser tab, ensuring they don't lead to a referrer/opener exploit.