### PR TITLE
Add firefox-source-docs.mozilla.org to Untracked Sites

### DIFF
--- a/httpobsdashboard/conf/sites.json
+++ b/httpobsdashboard/conf/sites.json
@@ -394,6 +394,7 @@
         "events.webmaker.org",
         "fb-affiliates.mozilla.org",
         "fhr.data.mozilla.com",
+        "firefox-source-docs.mozilla.org",
         "foro.mozilla-hispano.org",
         "forum.learning.mozilla.org",
         "forum.mozilla-russia.org",


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1392765 for details