### PR TITLE
Bug 1471541 - api.pub.build.mozilla.org url is deprecated

### DIFF
--- a/httpobsdashboard/conf/sites.json
+++ b/httpobsdashboard/conf/sites.json
@@ -199,7 +199,6 @@
         "mzl.la"
       ],
       "Release Engineering": [
-        "api.pub.build.mozilla.org",
         "mozilla-releng.net",
         "secure.pub.build.mozilla.org"
       ],


### PR DESCRIPTION
new one is mozilla-releng.net which is already present there.